### PR TITLE
Add option to specify a custom SMTP port

### DIFF
--- a/packages/mail/index.ts
+++ b/packages/mail/index.ts
@@ -7,6 +7,7 @@ config();
 
 const EMAIL_FROM = process.env.EMAIL_FROM || "";
 const EMAIL_HOST = process.env.EMAIL_HOST || "";
+const EMAIL_PORT = process.env.EMAIL_PORT || 465;
 const EMAIL_PASSWORD = process.env.EMAIL_PASSWORD || "";
 
 const SES_SECRET = process.env.SES_SECRET || "";
@@ -32,7 +33,7 @@ export const setupTransporter = () => {
   } else {
     transporter = createTransport({
       host: EMAIL_HOST,
-      port: 465,
+      port: EMAIL_PORT,
       secure: true,
       auth: {
         user: EMAIL_FROM,


### PR DESCRIPTION
Hi

I am using MailHog to test locally, and by default it listens on port 1025. Binding on port 465 requires root privileges, and I'd rather avoid that. Figured it might be useful for others too.